### PR TITLE
Add an uncaught exceptions settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
- - oraclejdk8
+ - openjdk8
 
 script:
  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.issue.ignore.multicriteria="e1" -Dsonar.issue.ignore.multicriteria.e1.ruleKey="squid:S00119" -Dsonar.issue.ignore.multicriteria.e1.resourceKey="**/*.java"

--- a/README.adoc
+++ b/README.adoc
@@ -41,12 +41,12 @@ In this case, StressTestRunner provide you an ability to check synchronization o
 ----
 @Test
 void concurrentThreadsSubTasks() {
-    ConcurrentTestRunner.test()
-                        .mode(ExecutionMode.TASK_EXECUTOR_MODE)  <1>
-                        .timeout(5, TimeUnit.SECONDS) <2>
-                        .threads(4)   <3>
-                        .iterations(100)  <4>
-                        .run(this::createSubTaskSingleTest); <5>
+    StressTestRunner.test()
+                    .mode(ExecutionMode.TASK_EXECUTOR_MODE)  <1>
+                    .timeout(5, TimeUnit.SECONDS) <2>
+                    .threads(4)   <3>
+                    .iterations(100)  <4>
+                    .run(this::createSubTaskSingleTest); <5>
 }
 
 private void createSubTaskSingleTest() throws Exception {

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ You need to add a next dependency:
 </dependency>
 ----
 
-## Stress testing REST API
+### REST API stress testing
 
 Let's consider a simple web application :
 

--- a/src/main/java/com/jupiter/tools/stress/test/concurrency/StressTestRunner.java
+++ b/src/main/java/com/jupiter/tools/stress/test/concurrency/StressTestRunner.java
@@ -1,15 +1,20 @@
 package com.jupiter.tools.stress.test.concurrency;
 
+import java.util.concurrent.TimeUnit;
+
 import com.jupiter.tools.stress.test.concurrency.strategy.TestRunnerFactory;
 import com.jupiter.tools.stress.test.concurrency.testrunner.Duration;
 import com.jupiter.tools.stress.test.concurrency.testrunner.OneIterationTestResult;
 import com.jupiter.tools.stress.test.concurrency.testrunner.TestRunnerResult;
 import com.jupiter.tools.stress.test.concurrency.testrunner.TestRunnerSettings;
-
 import org.junit.jupiter.api.Assertions;
-import java.util.concurrent.TimeUnit;
 
-import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.*;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_CATCH_UNCAUGHT_EXCEPTION;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_ITERATIONS;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_MODE;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_THREADS;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_TIMEOUT_DURATION;
+import static com.jupiter.tools.stress.test.concurrency.StressTestRunner.DefaultSettings.DEFAULT_TIMEOUT_UNIT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -35,89 +40,98 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class StressTestRunner {
 
-    private TestRunnerFactory testRunnerFactory;
-    private TestRunnerSettings settings;
-    private ExecutionMode mode;
+	private TestRunnerFactory testRunnerFactory;
+	private TestRunnerSettings settings;
+	private ExecutionMode mode;
 
-    private StressTestRunner(TestRunnerFactory factory) {
-        this.testRunnerFactory = factory;
-        this.settings = new TestRunnerSettings(DEFAULT_ITERATIONS,
-                                               DEFAULT_THREADS,
-                                               new Duration(DEFAULT_TIMEOUT_DURATION,
-                                                            DEFAULT_TIMEOUT_UNIT));
-        this.mode = DEFAULT_MODE;
-    }
+	private StressTestRunner(TestRunnerFactory factory) {
+		this.testRunnerFactory = factory;
+		this.settings = new TestRunnerSettings(DEFAULT_ITERATIONS,
+		                                       DEFAULT_THREADS,
+		                                       new Duration(DEFAULT_TIMEOUT_DURATION,
+		                                                    DEFAULT_TIMEOUT_UNIT),
+		                                       DEFAULT_CATCH_UNCAUGHT_EXCEPTION);
+		this.mode = DEFAULT_MODE;
+	}
 
-    /**
-     * factory method
-     *
-     * @return ConcurrentTestRunner
-     */
-    public static StressTestRunner test() {
-        return new StressTestRunner(new TestRunnerFactory());
-    }
+	/**
+	 * factory method
+	 *
+	 * @return ConcurrentTestRunner
+	 */
+	public static StressTestRunner test() {
+		return new StressTestRunner(new TestRunnerFactory());
+	}
 
-    /**
-     * Set iteration counter
-     */
-    public StressTestRunner iterations(int iterations) {
-        this.settings.setIterationCount(iterations);
-        return this;
-    }
+	/**
+	 * Set iteration counter
+	 */
+	public StressTestRunner iterations(int iterations) {
+		this.settings.setIterationCount(iterations);
+		return this;
+	}
 
-    /**
-     * Set threads count for EXECUTOR_MODE
-     *
-     * @param threadsCount count of threads for ThreadPoolTaskExecutor
-     */
-    public StressTestRunner threads(int threadsCount) {
-        this.settings.setThreadCount(threadsCount);
-        return this;
-    }
+	/**
+	 * Set threads count for EXECUTOR_MODE
+	 *
+	 * @param threadsCount count of threads for ThreadPoolTaskExecutor
+	 */
+	public StressTestRunner threads(int threadsCount) {
+		this.settings.setThreadCount(threadsCount);
+		return this;
+	}
 
-    /**
-     * Set the mode of concurrently running
-     *
-     * @param mode ExecutionMode (by stream().parallel() or by ThreadPoolTaskExecutor)
-     */
-    public StressTestRunner mode(ExecutionMode mode) {
-        this.mode = mode;
-        return this;
-    }
+	/**
+	 * Set the mode of concurrently running
+	 *
+	 * @param mode ExecutionMode (by stream().parallel() or by ThreadPoolTaskExecutor)
+	 */
+	public StressTestRunner mode(ExecutionMode mode) {
+		this.mode = mode;
+		return this;
+	}
 
-    /**
-     * Set a time limit for test execution
-     *
-     * @param duration after this interval test will fail if not complete
-     * @param unit     measure unit for timeout
-     */
-    public StressTestRunner timeout(int duration, TimeUnit unit) {
-        this.settings.setTimeout(new Duration(duration, unit));
-        return this;
-    }
+	/**
+	 * Set a time limit for test execution
+	 *
+	 * @param duration after this interval test will fail if not complete
+	 * @param unit     measure unit for timeout
+	 */
+	public StressTestRunner timeout(int duration, TimeUnit unit) {
+		this.settings.setTimeout(new Duration(duration, unit));
+		return this;
+	}
 
-    /**
-     * Run the test case method with selected execution mode
-     *
-     * @param testCase method that need to run concurrently
-     */
-    public void run(CallableVoid testCase) {
-        // Act
-        TestRunnerResult result = testRunnerFactory.get(this.mode)
-                                                   .run(testCase, settings);
-        // Assert
-        Assertions.assertAll(() -> assertThat(result.getErrors()).isEmpty(),
-                             () -> assertThat(result.getResults()).containsOnly(OneIterationTestResult.OK));
-    }
 
-    static class DefaultSettings {
-        static final int DEFAULT_ITERATIONS = 10;
-        static final int DEFAULT_THREADS = 4;
-        static final ExecutionMode DEFAULT_MODE = ExecutionMode.PARALLEL_STREAM_MODE;
-        static final long DEFAULT_TIMEOUT_DURATION = 100;
-        static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
+	public StressTestRunner dontCatchUncaughtExceptions() {
+		this.settings.setDontCatchUncaughtExceptions(true);
+		return this;
+	}
 
-        private DefaultSettings() {
-        }
-    }
+
+	/**
+	 * Run the test case method with selected execution mode
+	 *
+	 * @param testCase method that need to run concurrently
+	 */
+	public void run(CallableVoid testCase) {
+		// Act
+		TestRunnerResult result = testRunnerFactory.get(this.mode)
+		                                           .run(testCase, settings);
+		// Assert
+		Assertions.assertAll(() -> assertThat(result.getErrors()).isEmpty(),
+		                     () -> assertThat(result.getResults()).containsOnly(OneIterationTestResult.OK));
+	}
+
+	static class DefaultSettings {
+		static final boolean DEFAULT_CATCH_UNCAUGHT_EXCEPTION = false;
+		static final int DEFAULT_ITERATIONS = 10;
+		static final int DEFAULT_THREADS = 4;
+		static final ExecutionMode DEFAULT_MODE = ExecutionMode.PARALLEL_STREAM_MODE;
+		static final long DEFAULT_TIMEOUT_DURATION = 100;
+		static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+		private DefaultSettings() {
+		}
+	}
 }

--- a/src/main/java/com/jupiter/tools/stress/test/concurrency/StressTestRunner.java
+++ b/src/main/java/com/jupiter/tools/stress/test/concurrency/StressTestRunner.java
@@ -72,7 +72,11 @@ public class StressTestRunner {
 	}
 
 	/**
-	 * Set threads count for EXECUTOR_MODE
+	 * Set threads count.
+	 * <p>
+	 * This setting work only with the {@link ExecutionMode#EXECUTOR_MODE},
+	 * if you use {@link ExecutionMode#PARALLEL_STREAM_MODE} then
+	 * you cannot be able to set a thread count.
 	 *
 	 * @param threadsCount count of threads for ThreadPoolTaskExecutor
 	 */
@@ -92,17 +96,26 @@ public class StressTestRunner {
 	}
 
 	/**
-	 * Set a time limit for test execution
+	 * Set a time limit for test execution.
+	 * <p>
+	 * This setting may works unpredicted with the {@link ExecutionMode#PARALLEL_STREAM_MODE},
+	 * if you need a more precise measurement please try to use {@link ExecutionMode#EXECUTOR_MODE}.
 	 *
 	 * @param duration after this interval test will fail if not complete
 	 * @param unit     measure unit for timeout
+	 * @return StressTestRunner
 	 */
 	public StressTestRunner timeout(int duration, TimeUnit unit) {
 		this.settings.setTimeout(new Duration(duration, unit));
 		return this;
 	}
 
-
+	/**
+	 * Don't catch uncaught exceptions in other threads.
+	 * This will not make the run statement fail if exceptions occur in other threads.
+	 *
+	 * @return StressTestRunner
+	 */
 	public StressTestRunner dontCatchUncaughtExceptions() {
 		this.settings.setDontCatchUncaughtExceptions(true);
 		return this;

--- a/src/main/java/com/jupiter/tools/stress/test/concurrency/strategy/ThreadPoolExecutorTestRunner.java
+++ b/src/main/java/com/jupiter/tools/stress/test/concurrency/strategy/ThreadPoolExecutorTestRunner.java
@@ -1,5 +1,14 @@
 package com.jupiter.tools.stress.test.concurrency.strategy;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import com.jupiter.tools.stress.test.concurrency.CallableVoid;
 import com.jupiter.tools.stress.test.concurrency.testrunner.OneIterationTestResult;
 import com.jupiter.tools.stress.test.concurrency.testrunner.TestRunner;
@@ -8,11 +17,6 @@ import com.jupiter.tools.stress.test.concurrency.testrunner.TestRunnerSettings;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.*;
-import java.util.stream.Collectors;
 
 /**
  * Created on 13.09.2018.
@@ -24,47 +28,55 @@ import java.util.stream.Collectors;
  */
 public class ThreadPoolExecutorTestRunner implements TestRunner {
 
-    private Logger log = LoggerFactory.getLogger("stress-test:");
+	private Logger log = LoggerFactory.getLogger("stress-test:");
 
-    @Override
-    public TestRunnerResult run(CallableVoid testCase, TestRunnerSettings settings) {
+	@Override
+	public TestRunnerResult run(CallableVoid testCase, TestRunnerSettings settings) {
 
-        List<Throwable> errors = initEmptyErrorList();
-        List<Future<OneIterationTestResult>> futureList = new ArrayList<>();
-        ThreadPoolExecutor executor = initThreadPool(settings.getThreadCount());
+		List<Throwable> errors = initEmptyErrorList();
+		List<Future<OneIterationTestResult>> futureList = new ArrayList<>();
+		ThreadPoolExecutor executor = initThreadPool(settings.getThreadCount());
 
-        for (int i = 0; i < settings.getIterationCount(); i++) {
-            futureList.add(executor.submit(() -> executeOneIterationResult(testCase, errors)));
-        }
+		for (int i = 0; i < settings.getIterationCount(); i++) {
+			futureList.add(executor.submit(() -> executeOneIterationResult(testCase, errors)));
+		}
 
-        Awaitility.await()
-                  .atMost(settings.getTimeout().getDuration(),
-                          settings.getTimeout().getTimeUnit())
-                  .until(() -> futureList.stream().allMatch(Future::isDone));
+		if (settings.isDontCatchUncaughtExceptions()) {
+			Awaitility.await()
+			          .dontCatchUncaughtExceptions()
+			          .atMost(settings.getTimeout().getDuration(),
+			                  settings.getTimeout().getTimeUnit())
+			          .until(() -> futureList.stream().allMatch(Future::isDone));
+		} else {
+			Awaitility.await()
+			          .atMost(settings.getTimeout().getDuration(),
+			                  settings.getTimeout().getTimeUnit())
+			          .until(() -> futureList.stream().allMatch(Future::isDone));
+		}
 
-        List<OneIterationTestResult> results = futureList.stream()
-                                                         .map(this::getFutureTestResult)
-                                                         .collect(Collectors.toList());
+		List<OneIterationTestResult> results = futureList.stream()
+		                                                 .map(this::getFutureTestResult)
+		                                                 .collect(Collectors.toList());
 
-        return new TestRunnerResult(errors, results);
-    }
+		return new TestRunnerResult(errors, results);
+	}
 
-    private OneIterationTestResult getFutureTestResult(Future<OneIterationTestResult> f) {
-        try {
-            return f.get();
-        } catch (Exception e) {
-            log.error("get a result of the iteration failed: ", e);
-            return OneIterationTestResult.FAIL;
-        }
-    }
+	private OneIterationTestResult getFutureTestResult(Future<OneIterationTestResult> f) {
+		try {
+			return f.get();
+		} catch (Exception e) {
+			log.error("get a result of the iteration failed: ", e);
+			return OneIterationTestResult.FAIL;
+		}
+	}
 
-    private ThreadPoolExecutor initThreadPool(int threadCount) {
+	private ThreadPoolExecutor initThreadPool(int threadCount) {
 
-        BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(Integer.MAX_VALUE);
-        return new ThreadPoolExecutor(threadCount,
-                                      Integer.MAX_VALUE,
-                                      60,
-                                      TimeUnit.SECONDS,
-                                      queue);
-    }
+		BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>(Integer.MAX_VALUE);
+		return new ThreadPoolExecutor(threadCount,
+		                              Integer.MAX_VALUE,
+		                              60,
+		                              TimeUnit.SECONDS,
+		                              queue);
+	}
 }

--- a/src/main/java/com/jupiter/tools/stress/test/concurrency/testrunner/TestRunnerSettings.java
+++ b/src/main/java/com/jupiter/tools/stress/test/concurrency/testrunner/TestRunnerSettings.java
@@ -28,4 +28,9 @@ public class TestRunnerSettings {
      * time limit to test execution
      */
     private Duration timeout;
+
+    /**
+     * if true then don't catch uncaught exceptions in other threads
+     */
+    private boolean dontCatchUncaughtExceptions;
 }

--- a/src/test/java/com/jupiter/tools/stress/test/concurrency/StressTestRunnerTest.java
+++ b/src/test/java/com/jupiter/tools/stress/test/concurrency/StressTestRunnerTest.java
@@ -135,13 +135,13 @@ class StressTestRunnerTest {
 		Assertions.assertThrows(Exception.class,
 		                        () -> {
 			                        StressTestRunner.test()
-			                                        .iterations(10)
+			                                        .iterations(1000)
 			                                        .threads(1)
 			                                        .mode(ExecutionMode.PARALLEL_STREAM_MODE)
-			                                        .timeout(1, TimeUnit.SECONDS)
+			                                        .timeout(100, TimeUnit.MILLISECONDS)
 			                                        .run(() -> {
 				                                        System.out.println("RUN");
-				                                        Thread.sleep(1000);
+				                                        Thread.sleep(500);
 			                                        });
 		                        });
 	}

--- a/src/test/java/com/jupiter/tools/stress/test/concurrency/StressTestRunnerTest.java
+++ b/src/test/java/com/jupiter/tools/stress/test/concurrency/StressTestRunnerTest.java
@@ -1,12 +1,13 @@
 package com.jupiter.tools.stress.test.concurrency;
 
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,153 +18,174 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class StressTestRunnerTest {
 
-    private static final int ITERATIONS = 100000;
-    private static final int THREADS = 32;
+	private static final int ITERATIONS = 100000;
+	private static final int THREADS = 32;
 
-    @Test
-    @DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
-    void testConcurrentFailWithoutSync() {
-        // Arrange
-        NonAtomicInt value = new NonAtomicInt(0);
-        // Act
-        StressTestRunner.test()
-                        .threads(THREADS)
-                        .mode(ExecutionMode.EXECUTOR_MODE)
-                        .iterations(ITERATIONS)
-                        .run(value::increment);
-        // Asserts
-        assertThat(value.getValue()).isNotEqualTo(ITERATIONS);
-    }
+	@Test
+	@DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
+	void testConcurrentFailWithoutSync() {
+		// Arrange
+		NonAtomicInt value = new NonAtomicInt(0);
+		// Act
+		StressTestRunner.test()
+		                .threads(THREADS)
+		                .mode(ExecutionMode.EXECUTOR_MODE)
+		                .iterations(ITERATIONS)
+		                .run(value::increment);
+		// Asserts
+		assertThat(value.getValue()).isNotEqualTo(ITERATIONS);
+	}
 
-    @Test
-    @DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
-    void testConcurrentFail_toShowFailList() {
-        // Arrange
-        NonAtomicInt value = new NonAtomicInt(0);
+	@Test
+	@DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
+	void testConcurrentFail_toShowFailList() {
+		// Arrange
+		NonAtomicInt value = new NonAtomicInt(0);
 
-        Error error = Assertions.assertThrows(Error.class, () -> {
-            // Act
-            StressTestRunner.test()
-                            .iterations(ITERATIONS)
-                            .run(() -> {
-                                int expected = value.getValue() + 1;
-                                value.increment();
-                                // Assert
-                                assertThat(value.getValue()).isEqualTo(expected);
-                            });
-        });
-        // Assert
-        assertThat(value.getValue()).isNotEqualTo(ITERATIONS);
-        error.printStackTrace();
-    }
+		Error error = Assertions.assertThrows(Error.class, () -> {
+			// Act
+			StressTestRunner.test()
+			                .iterations(ITERATIONS)
+			                .run(() -> {
+				                int expected = value.getValue() + 1;
+				                value.increment();
+				                // Assert
+				                assertThat(value.getValue()).isEqualTo(expected);
+			                });
+		});
+		// Assert
+		assertThat(value.getValue()).isNotEqualTo(ITERATIONS);
+		error.printStackTrace();
+	}
 
-    @Test
-    void testConcurrentWithSync() {
-        // Arrange
-        NonAtomicInt value = new NonAtomicInt(0);
-        // Act
-        StressTestRunner.test()
-                        .iterations(ITERATIONS)
-                        .run(() -> {
-                            synchronized (this) {
-                                value.increment();
-                            }
-                        });
-        // Asserts
-        assertThat(value.getValue()).isEqualTo(ITERATIONS);
-    }
+	@Test
+	void testConcurrentWithSync() {
+		// Arrange
+		NonAtomicInt value = new NonAtomicInt(0);
+		// Act
+		StressTestRunner.test()
+		                .iterations(ITERATIONS)
+		                .run(() -> {
+			                synchronized (this) {
+				                value.increment();
+			                }
+		                });
+		// Asserts
+		assertThat(value.getValue()).isEqualTo(ITERATIONS);
+	}
 
-    @Test
-    @Disabled("only to debug")
-    void thr() {
-        StressTestRunner.test()
-                        .mode(ExecutionMode.EXECUTOR_MODE)
-                        .threads(THREADS)
-                        .iterations(ITERATIONS)
-                        .run(() -> System.out.println(Thread.currentThread().getName()));
-    }
+	@Test
+	@Disabled("only to debug")
+	void thr() {
+		StressTestRunner.test()
+		                .mode(ExecutionMode.EXECUTOR_MODE)
+		                .threads(THREADS)
+		                .iterations(ITERATIONS)
+		                .run(() -> System.out.println(Thread.currentThread().getName()));
+	}
 
-    @Test
-    void testTimeoutExecutorMode() {
+	@Test
+	void testTimeoutExecutorMode() {
 
-        StressTestRunner.test()
-                        .iterations(1)
-                        .threads(1)
-                        .mode(ExecutionMode.EXECUTOR_MODE)
-                        .timeout(5, TimeUnit.SECONDS)
-                        .run(() -> {
-                            System.out.println("RUN");
-                            Thread.sleep(1000);
-                        });
-    }
+		StressTestRunner.test()
+		                .iterations(1)
+		                .threads(1)
+		                .mode(ExecutionMode.EXECUTOR_MODE)
+		                .timeout(5, TimeUnit.SECONDS)
+		                .run(() -> {
+			                System.out.println("RUN");
+			                Thread.sleep(1000);
+		                });
+	}
 
-    @Test
-    void testTimeoutExecutorModeError() {
+	@Test
+	void testTimeoutExecutorModeError() {
 
-        Assertions.assertThrows(Exception.class, () -> {
+		Assertions.assertThrows(Exception.class, () -> {
 
-            StressTestRunner.test()
-                            .iterations(1)
-                            .threads(1)
-                            .mode(ExecutionMode.EXECUTOR_MODE)
-                            .timeout(1, TimeUnit.SECONDS)
-                            .run(() -> {
-                                System.out.println("RUN");
-                                Thread.sleep(2000);
-                            });
-        });
-    }
+			StressTestRunner.test()
+			                .iterations(1)
+			                .threads(1)
+			                .mode(ExecutionMode.EXECUTOR_MODE)
+			                .timeout(1, TimeUnit.SECONDS)
+			                .run(() -> {
+				                System.out.println("RUN");
+				                Thread.sleep(2000);
+			                });
+		});
+	}
 
-    @Test
-    void testTimeoutParallelMode() {
+	@Test
+	void testTimeoutParallelMode() {
 
-        StressTestRunner.test()
-                        .iterations(1)
-                        .threads(1)
-                        .mode(ExecutionMode.PARALLEL_STREAM_MODE)
-                        .timeout(5, TimeUnit.SECONDS)
-                        .run(() -> {
-                            System.out.println("RUN");
-                            Thread.sleep(1000);
-                        });
-    }
+		StressTestRunner.test()
+		                .iterations(1)
+		                .threads(1)
+		                .mode(ExecutionMode.PARALLEL_STREAM_MODE)
+		                .timeout(5, TimeUnit.SECONDS)
+		                .run(() -> {
+			                System.out.println("RUN");
+			                Thread.sleep(1000);
+		                });
+	}
 
-    @Test
-    void testTimeoutParallelModeError() {
+	@Test
+	void testTimeoutParallelModeError() {
 
-        Assertions.assertThrows(Exception.class,
-                                () -> {
-                                    StressTestRunner.test()
-                                                    .iterations(10)
-                                                    .threads(1)
-                                                    .mode(ExecutionMode.PARALLEL_STREAM_MODE)
-                                                    .timeout(1, TimeUnit.SECONDS)
-                                                    .run(() -> {
-                                                        System.out.println("RUN");
-                                                        Thread.sleep(1000);
-                                                    });
-                                });
-    }
+		Assertions.assertThrows(Exception.class,
+		                        () -> {
+			                        StressTestRunner.test()
+			                                        .iterations(10)
+			                                        .threads(1)
+			                                        .mode(ExecutionMode.PARALLEL_STREAM_MODE)
+			                                        .timeout(1, TimeUnit.SECONDS)
+			                                        .run(() -> {
+				                                        System.out.println("RUN");
+				                                        Thread.sleep(1000);
+			                                        });
+		                        });
+	}
 
-    @Test
-    void failInTestParallelMode() {
-        Assertions.assertThrows(Error.class,
-                                () -> StressTestRunner.test()
-                                                      .mode(ExecutionMode.PARALLEL_STREAM_MODE)
-                                                      .iterations(1)
-                                                      .run(() -> {
-                                                          throw new RuntimeException("oops");
-                                                      }));
-    }
+	@Test
+	void failInTestParallelMode() {
+		Assertions.assertThrows(Error.class,
+		                        () -> StressTestRunner.test()
+		                                              .mode(ExecutionMode.PARALLEL_STREAM_MODE)
+		                                              .iterations(1)
+		                                              .run(() -> {
+			                                              throw new RuntimeException("oops");
+		                                              }));
+	}
 
-    @Test
-    void failInTestExecutorMode() {
-        Assertions.assertThrows(Error.class,
-                                () -> StressTestRunner.test()
-                                                      .mode(ExecutionMode.EXECUTOR_MODE)
-                                                      .iterations(1)
-                                                      .run(() -> {
-                                                          throw new RuntimeException("oops");
-                                                      }));
-    }
+	@Test
+	void failInTestExecutorMode() {
+		Assertions.assertThrows(Error.class,
+		                        () -> StressTestRunner.test()
+		                                              .mode(ExecutionMode.EXECUTOR_MODE)
+		                                              .iterations(1)
+		                                              .run(() -> {
+			                                              throw new RuntimeException("oops");
+		                                              }));
+	}
+
+	@Test
+	void testDontCatchUncaughtExceptions() throws InterruptedException {
+
+		AtomicInteger counter = new AtomicInteger(0);
+
+		StressTestRunner.test()
+		                .mode(ExecutionMode.EXECUTOR_MODE)
+		                .dontCatchUncaughtExceptions()
+		                .threads(2)
+		                .iterations(20)
+		                .run(() -> {
+			                new Thread(() -> {
+				                throw new RuntimeException(Thread.currentThread().getName() + "-oops");
+			                }).start();
+			                Thread.sleep(100);
+			                counter.incrementAndGet();
+		                });
+
+		assertThat(counter.get()).isEqualTo(20);
+	}
 }

--- a/src/test/java/com/jupiter/tools/stress/test/extension/benchmark/BenchmarkExtensionFailCasesTest.java
+++ b/src/test/java/com/jupiter/tools/stress/test/extension/benchmark/BenchmarkExtensionFailCasesTest.java
@@ -3,6 +3,7 @@ package com.jupiter.tools.stress.test.extension.benchmark;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.EnableTestBenchmark;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.Fast;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.TestBenchmark;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.testkit.engine.EngineTestKit;
 


### PR DESCRIPTION
`dontCatchUncaughtExceptions()` provide an ability to ignore exceptions from other threads, 
the next test works fine unlike the version without `dontCatchUncaughtExceptions()`:

```java
@Test
void testDontCatchUncaughtExceptions() throws InterruptedException {

	AtomicInteger counter = new AtomicInteger(0);

	StressTestRunner.test()
	                .mode(ExecutionMode.EXECUTOR_MODE)
	                .dontCatchUncaughtExceptions()
	                .run(() -> {
		                new Thread(() -> {
			                throw new RuntimeException( "oops");
		                }).start();
		                Thread.sleep(100);
		                counter.incrementAndGet();
	                });

	assertThat(counter.get()).isEqualTo(20);
}
```


also, in this PR fixed #3 issue