### PR TITLE
Upgrade to latest versions of dependencies (JUnit5, AssertJ, ...)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ You need to add the following dependency:
 <dependency>
     <groupId>com.jupiter-tools</groupId>
     <artifactId>stress-test</artifactId>
-    <version>0.1</version>
+    <version>0.2</version>
     <scope>test</scope>
 </dependency>
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.jupiter-tools</groupId>
     <artifactId>stress-test</artifactId>
-    <version>0.1</version>
+    <version>0.2</version>
     <packaging>jar</packaging>
 
     <name>stress-test</name>
@@ -34,12 +34,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-versions-plugin.version>2.14.1</maven-versions-plugin.version>
         <java.version>1.8</java.version>    
         <junit.vintage.version>5.4.0</junit.vintage.version>
-        <junit-jupiter.version>5.4.0</junit-jupiter.version>
-        <junit-platform.version>1.4.0</junit-platform.version>
-        <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
+        <junit-jupiter.version>5.9.2</junit-jupiter.version>
+        <junit-platform.version>1.9.2</junit-platform.version>
     </properties>
 
     <developers>
@@ -95,25 +95,25 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.9.1</version>
+            <version>3.24.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.0</version>
+            <version>4.2.0</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.4.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.20</version>
+            <version>1.18.26</version>
         </dependency>
 
     </dependencies>
@@ -217,11 +217,6 @@
                 </configuration>
 
                 <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>

--- a/src/test/java/com/jupiter/tools/stress/test/extension/benchmark/BenchmarkExtensionFailCasesTest.java
+++ b/src/test/java/com/jupiter/tools/stress/test/extension/benchmark/BenchmarkExtensionFailCasesTest.java
@@ -3,7 +3,6 @@ package com.jupiter.tools.stress.test.extension.benchmark;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.EnableTestBenchmark;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.Fast;
 import com.jupiter.tools.stress.test.extension.benchmark.annotation.TestBenchmark;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
@@ -22,7 +21,7 @@ class BenchmarkExtensionFailCasesTest {
                 .engine("junit-jupiter")
                 .selectors(selectClass(BenchmarkExtensionFailCase.class))
                 .execute()
-                .containers()
+                .containerEvents()
                 .assertStatistics(s -> {
                     s.failed(1);
                 });
@@ -41,7 +40,7 @@ class BenchmarkExtensionFailCasesTest {
                 .engine("junit-jupiter")
                 .selectors(selectClass(BenchmarkExtensionFailCase.class))
                 .execute()
-                .tests()
+                .testEvents()
                 .assertStatistics(stats -> {
                     stats.started(fast.measurementIterations() +
                                   fast.warmupIterations() +


### PR DESCRIPTION
This pull request updates a couple of outdated libraries to the latest ones. With the old version 0.1, I got exceptions in assertions when the project using the jar is on newer versions of AssertJ. See pom.xml for the changes. I have upgraded the version to 0.2, so it would be appreciated, if this version is also released.